### PR TITLE
The cli module has no method err(), should be error()

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var parse = function (func){
 
     utils.GetAllContainers(host, function (err, containers){
         if (err) {
-            return cli.err(err);
+            return cli.error(err);
         }
 
         return func(containers);
@@ -66,7 +66,7 @@ var fetchContainerDetails = function (containerID, detailBox) {
 // Get the containers.
 parse(function (containers) {
     if (containers.length <= 0){
-        return cli.err("No containers.")
+        return cli.error("No containers.")
     }
 
     // Create upper nested grid.


### PR DESCRIPTION
Fixes the following TypeError when unable to connect to docker socket

```
TypeError: Object #<Object> has no method 'err'
    at ~/src/docker-mon/index.js:38:24
    at Request._callback (~/src/docker-mon/utils/index.js:20:20)
    at self.callback (~/src/docker-mon/node_modules/request/request.js:373:22)
    at Request.emit (events.js:95:17)
    at Request.onRequestError (~/src/docker-mon/node_modules/request/request.js:971:8)
    at ClientRequest.emit (events.js:95:17)
    at Socket.socketErrorListener (http.js:1552:9)
    at Socket.emit (events.js:95:17)
    at net.js:441:14
    at process._tickCallback (node.js:442:13)
```

`npm install` installed `cli:v0.6.5`
