### PR TITLE
Some Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "blessed-contrib": "0.0.4",
     "cli": "^0.6.5",
     "humanize": "0.0.9",
+    "lodash": "^3.3.1",
     "mime-db": "1.5.0",
     "moment": "2.9.0",
     "request": "^2.51.0"

--- a/widgets/cpu.js
+++ b/widgets/cpu.js
@@ -9,7 +9,11 @@ calculateCPUPercent = function(statItem, previousCpu, previousSystem) {
     if (systemDelta > 0.0 && cpuDelta > 0.0) {
         cpuPercent = (cpuDelta / systemDelta) * statItem.cpu_stats.cpu_usage.percpu_usage.length * 100.0
     }
-    return cpuPercent
+    if(cpuPercent < 150){
+        return cpuPercent
+    } else {
+        return 0;
+    }
 }
 
 CPUPercentageLine = function (lineWidget) {
@@ -25,6 +29,13 @@ CPUPercentageLine = function (lineWidget) {
     this.previousSystem = 0.0
 }
 
+CPUPercentageLine.prototype.clear = function(){
+    this.x              = []
+    this.y              = []
+//    this.previousCpu    = 0.0
+//    this.previousSystem = 0.0
+}
+
 CPUPercentageLine.prototype.update = function (statItem) {
     var maxDataPoints = 60
     if (this.x.length > maxDataPoints) {
@@ -36,9 +47,12 @@ CPUPercentageLine.prototype.update = function (statItem) {
 
     var cpuPercent = calculateCPUPercent(statItem, this.previousCpu, this.previousSystem)
     //this.x.push(moment(statItem.read).format("HH:mm:ss"))
-    this.x.push(' ')
-    this.y.push(cpuPercent)
-
+  this.y.push(cpuPercent)
+  this.x = [];
+  for (var i = 0; i <= this.y.length; i++) {
+    this.x.push(i-1);
+  }
+  this.x = this.x.reverse().map(function(n){return n.toString()})
     this.previousCpu = statItem.cpu_stats.cpu_usage.total_usage
     this.previousSystem = statItem.cpu_stats.system_cpu_usage
 

--- a/widgets/gauges.js
+++ b/widgets/gauges.js
@@ -12,6 +12,11 @@ CPUGauge = function (gaugeWidget) {
     this.previousSystem = 0.0
 }
 
+CPUGauge.prototype.clear = function(){
+    this.previousCpu    = 0.0
+    this.previousSystem = 0.0
+}
+
 CPUGauge.prototype.update = function (statItem) {
     var cpuPercent = cpu.calculateCPUPercent(statItem, this.previousCpu, this.previousSystem)
     this.gauge.setPercent(Math.round(cpuPercent))


### PR DESCRIPTION
Fixes xlabels on CPU % to be # of measurements, capped at max. ex: for
60 datapoints when 32 have been collected:

```
32                    22                     12                    2
```

and when 60 have been collected (with a max of 60 total):

![screenshot 2015-03-01 07 50 51](https://cloud.githubusercontent.com/assets/551247/6431722/dff8959e-bfed-11e4-82c7-cd1a375b92ef.png)
- Containers list now shows only the running containers
- Containers list now updates once every second
- Cleaned up Streams for StatsStream (by removing it and using request's
  stream.)
